### PR TITLE
Unbreak package build on Ubuntu builds

### DIFF
--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -42,7 +42,7 @@ install:
 		upgrades-installed-check \
 		upgrades-status-notify
 	install -d -m 2775 $(DESTDIR)$(QUBESSTATEDIR)/dom0-updates
-ifneq (,$(filter $(DIST),buster bullseye bookworm))
+ifneq (,$(filter $(DIST),buster bullseye bookworm bionic focal))
 	install -D -m 0644 dnf-plugin-download.py \
 		$(DESTDIR)$(QUBESLIBDIR)/dnf-plugins/download.py
 endif


### PR DESCRIPTION
The packaging scripts attempt to install `download.py` and fail if it isn't present.